### PR TITLE
updated past gigs GET route for coach and user

### DIFF
--- a/server/routes/gig.router.js
+++ b/server/routes/gig.router.js
@@ -33,7 +33,9 @@ router.get('/past', rejectUnauthenticated, (req, res) => {
 	let sqlQuery = `
     SELECT * FROM "gig"
       WHERE "coach_user_id"=($1)
-      AND "status"=false;`;
+        AND "status"=false
+      OR "user_id"=($1)
+        AND "status"=false;`;
 
 	let sqlValues = [req.user.id];
 

--- a/src/components/Overview/Overview.jsx
+++ b/src/components/Overview/Overview.jsx
@@ -46,10 +46,10 @@ function Overview() {
         <br />
         <h2>Completed Gigs</h2>
         <ul>
-            {pastGigs.map(({ id, title, date_applied }) => {
+            {pastGigs.map(({ id, title, date_for_gig }) => {
                 return (
                     <li key={id}>
-                        <p>{title}, {convertDateFormat(date_applied)}</p>
+                        <p>{title}, {convertDateFormat(date_for_gig)}</p>
                     </li>
                 )
             })}


### PR DESCRIPTION
- for completed gigs in Overview component, now rendering "date_for_gig" instead of "date_applied"
- updated SQL query in the GET route for past gigs so that both gigs created by a user, and gigs accepted/applied to by a user are being retrieved 